### PR TITLE
Thingy not workey, only making grayscaled versions

### DIFF
--- a/wallutils.sh
+++ b/wallutils.sh
@@ -99,7 +99,7 @@ defaultwall() {
     if [ -n "$1" ] && [ -n "$2" ]; then
         echo "generating custom image"
         convert overlay.png -fill "$1" -colorize 100 color.png
-        convert color.png -background "$2" -alpha remove -alpha off "$OUTNAME".png
+        convert color.png -background "$2" -flatten "$OUTNAME".png
     else
         echo "defaulting to theme colors"
         convert overlay.png -fill "$(instantforeground)" -colorize 100 color.png

--- a/wallutils.sh
+++ b/wallutils.sh
@@ -103,7 +103,7 @@ defaultwall() {
     else
         echo "defaulting to theme colors"
         convert overlay.png -fill "$(instantforeground)" -colorize 100 color.png
-        convert color.png -background "$(instantbackground)" -alpha remove -alpha off "$OUTNAME".png
+        convert color.png -background "$(instantbackground)" -flatten "$OUTNAME".png
     fi
 
     rm color.png


### PR DESCRIPTION
The background color of colored wallpapers are always grayscaled no matter the color set as `bgcolor`, this PR makes it so it actually displays the beautiful colors of this world.